### PR TITLE
Fix propogated error type

### DIFF
--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -720,9 +720,10 @@ def execute_mp(
                 # first entry on the error queue should hopefully be the original error, just raise that one single error
                 (task_name, task_err, traceback_str), _ = err_queue.get()
                 # should only be at most one unique error, just raise it
-                raise TaskError(
+                # the main error needs to be the main raise for type-based exception catching to work
+                raise task_err from TaskError(
                     f"Task; {task_name} errored\n{traceback_str}\n{task_err}"
-                ) from task_err
+                )
 
         except BaseException as err:  # pylint: disable=broad-except
             if not has_error:

--- a/pipeline_lib/tr_execution.py
+++ b/pipeline_lib/tr_execution.py
@@ -259,9 +259,8 @@ def execute_tr(tasks: List[PipelineTask], inactivity_timeout: Optional[float]):
                     ):
                         # should only be at most one unique error, just raise it
                         task_name, err, traceback_str = stream.error_info
-                        raise TaskError(
-                            f"Task; {task_name} errored\n{traceback_str}\n{err}"
-                        ) from err
+                        # somehow this error retains the full trackback, no reason to include the thread-specific traceback here
+                        raise err
 
             # check for weird unhandled errors (defensive coding, don't know of real world situations which would cause this)
             for done_id in done_sentinels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "0.4.1"
+version = "0.5.0"
 name = "pipeline_lib"
 description = "A streaming pipeline accelerator for Python"
 readme = "README.md"

--- a/test/test_execution_error.py
+++ b/test/test_execution_error.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 import numpy as np
 import psutil
 import pytest
+from pytest import raises
 
 import pipeline_lib
 from pipeline_lib import PipelineTask, execute
@@ -18,7 +19,6 @@ from .example_funcs import *
 from .test_utils import (
     all_parallelism_options,
     process_parallelism_options,
-    raises,
     sleeper,
     thread_parallelism_options,
 )

--- a/test/test_execution_error.py
+++ b/test/test_execution_error.py
@@ -18,7 +18,7 @@ from .example_funcs import *
 from .test_utils import (
     all_parallelism_options,
     process_parallelism_options,
-    raises_from,
+    raises,
     sleeper,
     thread_parallelism_options,
 )
@@ -48,7 +48,7 @@ def test_execute_exception(parallelism: ParallelismStrategy):
             print_numbers,
         ),
     ]
-    with raises_from(TestExpectedException):
+    with raises(TestExpectedException):
         execute(tasks, parallelism)
 
 
@@ -76,7 +76,7 @@ def test_sudden_exit_middle(parallelism: ParallelismStrategy):
             print_numbers,
         ),
     ]
-    with raises_from(SuddenExit):
+    with raises(SuddenExit):
         execute(tasks, parallelism)
 
 
@@ -91,7 +91,7 @@ def test_sudden_exit_end(parallelism: ParallelismStrategy):
         ),
         PipelineTask(print_numbers),
     ]
-    with raises_from(SuddenExit):
+    with raises(SuddenExit):
         execute(tasks, parallelism)
 
 
@@ -110,7 +110,7 @@ def test_sudden_exit_middle_sleepers(parallelism: ParallelismStrategy):
             print_numbers,
         ),
     ]
-    with raises_from(SuddenExit):
+    with raises(SuddenExit):
         execute(tasks, parallelism)
 
 
@@ -134,7 +134,7 @@ def test_inactivty_timeout(parallelism: ParallelismStrategy):
             print_numbers,
         ),
     ]
-    with raises_from(InactivityError):
+    with raises(InactivityError):
         execute(tasks, parallelism, inactivity_timeout=0.1)
 
 
@@ -267,7 +267,7 @@ def test_single_worker_error(parallelism: ParallelismStrategy):
         ),
         PipelineTask(print_numbers, num_workers=2, packets_in_flight=2),
     ]
-    with raises_from(TestExpectedException):
+    with raises(TestExpectedException):
         execute(tasks, parallelism)
 
 
@@ -314,7 +314,7 @@ def test_single_worker_unexpected_exit(parallelism: ParallelismStrategy):
         ),
         PipelineTask(print_numbers, num_workers=2, packets_in_flight=2),
     ]
-    with raises_from(pipeline_lib.pipeline_task.TaskError):
+    with raises(pipeline_lib.pipeline_task.TaskError):
         execute(tasks, parallelism)
 
 
@@ -355,9 +355,9 @@ def test_hang_message_passing_timeout(
         ),
         PipelineTask(print_numbers),
     ]
-    with raises_from(InactivityError):
+    with raises(InactivityError):
         execute(tasks, parallelism, inactivity_timeout=5)
 
 
 if __name__ == "__main__":
-    test_hang_message_passing_timeout(1000, 'process-fork')
+    test_hang_message_passing_timeout(1000, "process-fork")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -26,23 +26,3 @@ def sleeper(vals: Iterable[int], sleep_time: float) -> Iterable[int]:
     for i in vals:
         time.sleep(sleep_time)
         yield i
-
-
-@contextmanager
-def raises(err_type):
-    try:
-        yield
-    except Exception as err:
-        if isinstance(err, err_type):
-            # passes test
-            return
-        raise AssertionError(f"expected error of type {err_type} got error {err}")
-
-
-def test_raises_from():
-    # tests testing utility above
-    with pytest.raises(AssertionError):
-        with raises(RuntimeError):
-            raise ValueError()
-    with raises(ValueError):
-        raise ValueError()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,13 +29,11 @@ def sleeper(vals: Iterable[int], sleep_time: float) -> Iterable[int]:
 
 
 @contextmanager
-def raises_from(err_type):
+def raises(err_type):
     try:
         yield
     except Exception as err:
-        if isinstance(err, err_type) or (
-            err.__cause__ and isinstance(err.__cause__, err_type)
-        ):
+        if isinstance(err, err_type):
             # passes test
             return
         raise AssertionError(f"expected error of type {err_type} got error {err}")
@@ -44,7 +42,7 @@ def raises_from(err_type):
 def test_raises_from():
     # tests testing utility above
     with pytest.raises(AssertionError):
-        with raises_from(RuntimeError):
+        with raises(RuntimeError):
             raise ValueError()
-    with raises_from(ValueError):
+    with raises(ValueError):
         raise ValueError()


### PR DESCRIPTION
While the errors have been propagated, they have been stored in the `__cause__` attribute of the error, which is very hard to get at.

With the new changes, errors can be caught in the normal way:

```

from typing import Iterable

from pipeline_lib.execution import execute
from pipeline_lib.pipeline_task import PipelineTask
from test.example_funcs import generate_numbers, print_numbers


class SuddenExit(RuntimeError):
    pass


def sudden_exit_fn(arg: Iterable[int]) -> Iterable[int]:
    # start up input generator/process
    next(iter(arg))
    # thread raises exception so that python does not know about it
    raise SuddenExit("sudden exit")


def test_sudden_exit_middle():
    tasks = [
        PipelineTask(
            generate_numbers,
        ),
        PipelineTask(
            sudden_exit_fn,
        ),
        PipelineTask(
            print_numbers,
        ),
    ]
    try:
        execute(tasks, 'thread')
    except SuddenExit:
        print("Found Sudden Exit error!")


if __name__ == "__main__":
    test_sudden_exit_middle()

```