### PR TITLE
Daemon thread

### DIFF
--- a/pipeline_lib/tr_execution.py
+++ b/pipeline_lib/tr_execution.py
@@ -176,6 +176,7 @@ def execute_tr(tasks: List[PipelineTask], inactivity_timeout: Optional[float]):
             tr.Thread(
                 target=_start_source,
                 args=(source_task, data_streams[0], clean_completed),
+                daemon=True,
             ),
         )
     ]
@@ -277,6 +278,8 @@ def execute_tr(tasks: List[PipelineTask], inactivity_timeout: Optional[float]):
                 if stream.error_info is None:
                     stream.set_error("main_task", err)
         # clean up remaining threads so that main process terminates properly
+        # if the thread is not joined in 15 seconds, then the thread will end up as
+        # a detatched daemon thread, which should at least allow the process to eventually exit
         for _name, thread in threads:
             thread.join(15)
         raise err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "0.5.0"
+version = "0.5.1"
 name = "pipeline_lib"
 description = "A streaming pipeline accelerator for Python"
 readme = "README.md"


### PR DESCRIPTION
Pipeline lib threads should be daemon threads so the main process can exit more smoothly even in cases of hanging pipeline lib steps.

Sadly threads cannot be force-killed if there is a bug or inifinte loop in one of the threads