### PR TITLE
Thread-in-process execution methods

### DIFF
--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -107,7 +107,7 @@ def benchmark_execution():
     for n_msgs, buf_size, msg_type in zip(num_messages, buffer_sizes, message_types):
         results = []
         for comb in parameter_combinations:
-            start_t = time.time()
+            start_t = time.monotonic()
             run_messages(
                 n_procs=comb.n_procs,
                 packets_in_flight=comb.packets_in_flight,
@@ -116,7 +116,7 @@ def benchmark_execution():
                 message_type=msg_type,
                 max_message_size=buf_size,
             )
-            end_t = time.time()
+            end_t = time.monotonic()
             results.append(end_t - start_t)
         max_val = min(results)
         buf_type = "pipe" if buf_size is None else "shared-mem"

--- a/pipeline_lib/execution.py
+++ b/pipeline_lib/execution.py
@@ -6,8 +6,9 @@ from .mp_execution import execute_mp
 from .pipeline_task import PipelineTask
 from .seq_execution import execute_seq
 from .tr_execution import execute_tr
+from .trp_execution import execute_trp
 
-ParallelismStrategy = Literal["thread", "process-fork", "process-spawn", "coroutine"]
+ParallelismStrategy = Literal["thread", "process-fork", "process-spawn", "process-fork-threading", "process-spawn-threading", "coroutine"]
 
 # list of strings in ParallelismStrategy
 PARALLELISM_STRATEGIES: Tuple[str, ...] = get_args(ParallelismStrategy)
@@ -46,6 +47,10 @@ def execute(
         execute_mp(tasks, "spawn", inactivity_timeout=inactivity_timeout)
     elif parallelism == "process-fork":
         execute_mp(tasks, "fork", inactivity_timeout=inactivity_timeout)
+    elif parallelism == "process-spawn-threading":
+        execute_trp(tasks, "spawn", inactivity_timeout=inactivity_timeout)
+    elif parallelism == "process-fork-threading":
+        execute_trp(tasks, "fork", inactivity_timeout=inactivity_timeout)
     elif parallelism == "coroutine":
         assert (
             inactivity_timeout is None

--- a/pipeline_lib/execution.py
+++ b/pipeline_lib/execution.py
@@ -8,7 +8,14 @@ from .seq_execution import execute_seq
 from .tr_execution import execute_tr
 from .trp_execution import execute_trp
 
-ParallelismStrategy = Literal["thread", "process-fork", "process-spawn", "process-fork-threading", "process-spawn-threading", "coroutine"]
+ParallelismStrategy = Literal[
+    "thread",
+    "process-fork",
+    "process-spawn",
+    "process-fork-threading",
+    "process-spawn-threading",
+    "coroutine",
+]
 
 # list of strings in ParallelismStrategy
 PARALLELISM_STRATEGIES: Tuple[str, ...] = get_args(ParallelismStrategy)

--- a/pipeline_lib/execution.py
+++ b/pipeline_lib/execution.py
@@ -12,8 +12,8 @@ ParallelismStrategy = Literal[
     "thread",
     "process-fork",
     "process-spawn",
-    "process-fork-threading",
-    "process-spawn-threading",
+    "thread-in-process-fork",
+    "thread-in-process-spawn",
     "coroutine",
 ]
 
@@ -54,9 +54,9 @@ def execute(
         execute_mp(tasks, "spawn", inactivity_timeout=inactivity_timeout)
     elif parallelism == "process-fork":
         execute_mp(tasks, "fork", inactivity_timeout=inactivity_timeout)
-    elif parallelism == "process-spawn-threading":
+    elif parallelism == "thread-in-process-spawn":
         execute_trp(tasks, "spawn", inactivity_timeout=inactivity_timeout)
-    elif parallelism == "process-fork-threading":
+    elif parallelism == "thread-in-process-fork":
         execute_trp(tasks, "fork", inactivity_timeout=inactivity_timeout)
     elif parallelism == "coroutine":
         assert (

--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -753,7 +753,8 @@ def execute_mp(
                 # there should be at least some visiblity to the user if the process really still is running,
                 # so that logs can be searched to find hanging processes
                 if proc.is_alive():
-                    warnings.warn(f"Failed to join pipeline subprocess id: '{proc.pid}'")
-
+                    warnings.warn(
+                        f"Failed to join pipeline subprocess id: '{proc.pid}'"
+                    )
 
             raise err

--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -12,6 +12,7 @@ import threading as tr
 import time
 import traceback
 import typing
+import warnings
 from dataclasses import dataclass
 from functools import reduce
 from multiprocessing import synchronize
@@ -24,7 +25,6 @@ from multiprocessing.context import (
 )
 from operator import mul
 from typing import Any, Iterable, List, Literal, Optional, Set, Tuple, Union
-import warnings
 
 import cloudpickle
 

--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -431,7 +431,7 @@ class TaskOutput:
     ) -> None:
         # pylint: disable=too-many-arguments
         self.num_tasks_remaining = ctx.Value("i", num_upstream_tasks, lock=True)
-        self.last_updated_time = ctx.Value("d", time.time(), lock=False)
+        self.last_updated_time = ctx.Value("d", time.monotonic(), lock=False)
         self.queue_len = ctx.Semaphore(value=0)
         self.packets_space = ctx.Semaphore(value=packets_in_flight)
         # using a custom queue implementation rather than multiprocessing.queue
@@ -466,7 +466,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # update last updated time
-            self.last_updated_time.value = time.time()
+            self.last_updated_time.value = time.monotonic()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -689,9 +689,9 @@ def execute_mp(
                     last_updated_time = max(
                         float(stream.last_updated_time.value) for stream in data_streams
                     )
-                    if time.time() - last_updated_time > inactivity_timeout:
+                    if time.monotonic() - last_updated_time > inactivity_timeout:
                         raise InactivityError(
-                            f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                            f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                         )
 
                 sentinel_set -= set(done_sentinels)

--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -431,7 +431,7 @@ class TaskOutput:
     ) -> None:
         # pylint: disable=too-many-arguments
         self.num_tasks_remaining = ctx.Value("i", num_upstream_tasks, lock=True)
-        self.last_updated_time = ctx.Value("d", time.monotonic(), lock=False)
+        self.last_updated_time = ctx.Value("d", time.time(), lock=False)
         self.queue_len = ctx.Semaphore(value=0)
         self.packets_space = ctx.Semaphore(value=packets_in_flight)
         # using a custom queue implementation rather than multiprocessing.queue
@@ -466,7 +466,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # update last updated time
-            self.last_updated_time.value = time.monotonic()
+            self.last_updated_time.value = time.time()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -689,9 +689,9 @@ def execute_mp(
                     last_updated_time = max(
                         float(stream.last_updated_time.value) for stream in data_streams
                     )
-                    if time.monotonic() - last_updated_time > inactivity_timeout:
+                    if time.time() - last_updated_time > inactivity_timeout:
                         raise InactivityError(
-                            f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                            f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                         )
 
                 sentinel_set -= set(done_sentinels)

--- a/pipeline_lib/mp_execution.py
+++ b/pipeline_lib/mp_execution.py
@@ -24,6 +24,7 @@ from multiprocessing.context import (
 )
 from operator import mul
 from typing import Any, Iterable, List, Literal, Optional, Set, Tuple, Union
+import warnings
 
 import cloudpickle
 
@@ -746,6 +747,13 @@ def execute_mp(
             # force kill the processes (only if they are refusing to terminate cleanly)
             for proc in processes:
                 proc.kill()
-                proc.join()
+                proc.join(30.0)
+
+                # if somehow, this force-kill process didn't work, and the process is left hanging,
+                # there should be at least some visiblity to the user if the process really still is running,
+                # so that logs can be searched to find hanging processes
+                if proc.is_alive():
+                    warnings.warn(f"Failed to join pipeline subprocess id: '{proc.pid}'")
+
 
             raise err

--- a/pipeline_lib/tr_execution.py
+++ b/pipeline_lib/tr_execution.py
@@ -22,7 +22,7 @@ class TaskOutput:
         self.queue_len = Semaphore(value=0)
         self.packets_space = Semaphore(value=packets_in_flight)
         self.queue: deque = deque(maxlen=packets_in_flight)
-        self.last_updated_time = time.monotonic()
+        self.last_updated_time = time.time()
         self.lock = RLock()
         self.error_info = None
 
@@ -43,7 +43,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # store the updated time to register that progress was made in the pipeline
-            self.last_updated_time = time.monotonic()
+            self.last_updated_time = time.time()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -223,10 +223,10 @@ def execute_tr(tasks: List[PipelineTask], inactivity_timeout: Optional[float]):
                 )
                 if (
                     inactivity_timeout is not None
-                    and time.monotonic() - last_updated_time > inactivity_timeout
+                    and time.time() - last_updated_time > inactivity_timeout
                 ):
                     raise InactivityError(
-                        f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                        f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                     )
 
             done_sentinels = set()

--- a/pipeline_lib/tr_execution.py
+++ b/pipeline_lib/tr_execution.py
@@ -22,7 +22,7 @@ class TaskOutput:
         self.queue_len = Semaphore(value=0)
         self.packets_space = Semaphore(value=packets_in_flight)
         self.queue: deque = deque(maxlen=packets_in_flight)
-        self.last_updated_time = time.time()
+        self.last_updated_time = time.monotonic()
         self.lock = RLock()
         self.error_info = None
 
@@ -43,7 +43,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # store the updated time to register that progress was made in the pipeline
-            self.last_updated_time = time.time()
+            self.last_updated_time = time.monotonic()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -223,10 +223,10 @@ def execute_tr(tasks: List[PipelineTask], inactivity_timeout: Optional[float]):
                 )
                 if (
                     inactivity_timeout is not None
-                    and time.time() - last_updated_time > inactivity_timeout
+                    and time.monotonic() - last_updated_time > inactivity_timeout
                 ):
                     raise InactivityError(
-                        f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                        f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                     )
 
             done_sentinels = set()

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -398,6 +398,8 @@ def execute_trp(
             # there should be at least some visiblity to the user if the process really still is running,
             # so that logs can be searched to find hanging processes
             if subprocess.is_alive():
-                warnings.warn(f"Failed to join pipeline subprocess id: '{subprocess.pid}'")
+                warnings.warn(
+                    f"Failed to join pipeline subprocess id: '{subprocess.pid}'"
+                )
 
             raise err

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -390,6 +390,14 @@ def execute_trp(
             if not subprocess.exitcode:
                 # force kill the process (only if they are refusing to terminate cleanly)
                 subprocess.kill()
-                subprocess.join()
+                # this should exit very quickly after the force-kill, but putting a timeout on it anyways
+                # just so we can continue execution if the process hangs
+                subprocess.join(timeout=30.0)
+
+            # if somehow, this force-kill process didn't work, and the process is left hanging,
+            # there should be at least some visiblity to the user if the process really still is running,
+            # so that logs can be searched to find hanging processes
+            if subprocess.is_alive():
+                warnings.warn(f"Failed to join pipeline subprocess id: '{subprocess.pid}'")
 
             raise err

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -1,0 +1,299 @@
+from ctypes import Union
+import logging
+from multiprocessing.context import BaseContext, ForkContext, SpawnContext
+import threading as tr
+import time
+import typing
+import warnings
+from collections import deque
+from threading import RLock, Semaphore, get_native_id
+from typing import Any, Iterable, List, Optional, Set
+import multiprocessing as mp
+
+from pipeline_lib.mp_execution import ERR_BUF_SIZE, BufferedQueue, SpawnContextName
+
+from .pipeline_task import DEFAULT_BUF_SIZE, InactivityError, PipelineTask, TaskError
+from .type_checking import MAX_NUM_WORKERS, sanity_check_mp_params
+
+logger = logging.getLogger(__name__)
+
+
+class PropogateErr(RuntimeError):
+    pass
+
+
+class TaskOutput:
+    def __init__(self, num_upstream_tasks: int, packets_in_flight: int, err_queue: BufferedQueue, ctx: BaseContext,) -> None:
+        self.num_tasks_remaining = num_upstream_tasks
+        self.err_queue = err_queue
+        self.queue_len = Semaphore(value=0)
+        self.packets_space = Semaphore(value=packets_in_flight)
+        self.queue: deque = deque(maxlen=packets_in_flight)
+        self.last_updated_time = time.monotonic()
+        self.lock = RLock()
+        self.has_error = ctx.Event()
+
+    def iter_results(self) -> Iterable[Any]:
+        while True:
+            self.queue_len.acquire()  # pylint: disable=consider-using-with
+            if self.is_errored():
+                raise PropogateErr()
+            try:
+                item = self.queue.popleft()
+            except IndexError:
+                # only happens when out of results
+                return
+            yield item
+
+            # this release needs to happen after the yield
+            # completes to support full synchronization semantics with packets_in_flight=1
+            self.packets_space.release()
+
+            # store the updated time to register that progress was made in the pipeline
+            self.last_updated_time = time.monotonic()
+
+    def put_results(self, iterable: Iterable[Any]):
+        iterator = iter(iterable)
+        try:
+            while True:
+                # wait for space to be available on queue before iterating to next item
+                # essential for full synchronization semantics with packets_in_flight=1
+                self.packets_space.acquire()  # pylint: disable=consider-using-with
+
+                if self.is_errored():
+                    raise PropogateErr()
+
+                item = next(iterator)
+
+                self.queue.append(item)
+                self.queue_len.release()
+        except StopIteration:
+            # normal end of iteration
+            with self.lock:
+                self.num_tasks_remaining -= 1
+                if self.num_tasks_remaining == 0:
+                    for _i in range(MAX_NUM_WORKERS):
+                        self.queue_len.release()
+
+    def is_errored(self):
+        return self.has_error.is_set()
+
+    def set_error(self, task_name, err, traceback_str):
+        if not self.has_error.is_set():
+            self.err_queue.put((task_name, err, traceback_str))
+            self.has_error.set()
+
+        # release all consumers and producers semaphores so that they exit quickly
+        for _i in range(MAX_NUM_WORKERS):
+            self.queue_len.release()
+            self.packets_space.release()
+
+
+def _start_worker(
+    task: PipelineTask,
+    upstream: TaskOutput,
+    downstream: TaskOutput,
+    clean_completed: Set[int],
+):
+    try:
+        constants = {} if task.constants is None else task.constants
+        generator_input = upstream.iter_results()
+        out_iter = task.generator(generator_input, **constants)
+        downstream.put_results(out_iter)
+    except BaseException as err:  # pylint: disable=broad-except
+        # sets upstream and downstream so that error propagates throughout the system
+        downstream.set_error(task.name, err)
+        upstream.set_error(task.name, err)
+    finally:
+        clean_completed.add(get_native_id())
+
+
+def _start_source(
+    task: PipelineTask,
+    downstream: TaskOutput,
+    clean_completed: Set[int],
+):
+    try:
+        out_iter = task.generator(**task.constants_dict)
+        downstream.put_results(out_iter)
+    except BaseException as err:  # pylint: disable=broad-except
+        downstream.set_error(task.name, err)
+    finally:
+        clean_completed.add(get_native_id())
+
+
+def _start_sink(
+    task: PipelineTask,
+    upstream: TaskOutput,
+    clean_completed: Set[int],
+):
+    try:
+        generator_input = upstream.iter_results()
+        task.generator(generator_input, **task.constants_dict)
+    except BaseException as err:  # pylint: disable=broad-except
+        upstream.set_error(task.name, err)
+    finally:
+        clean_completed.add(get_native_id())
+
+
+def _warn_parameter_overrides(tasks: List[PipelineTask]):
+    for task in tasks:
+        if (
+            task.max_message_size is not None
+            and task.max_message_size != DEFAULT_BUF_SIZE
+        ):
+            warnings.warn(
+                f"Task '{task.name}' overrode default value of max_message_size, and this override is ignored by 'thread' parallelism strategy."
+            )
+
+
+def execute_trp(
+    tasks: List[PipelineTask],
+    spawn_method: SpawnContextName,
+    inactivity_timeout: Optional[float]
+):
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    """
+    execute tasks until final task completes.
+    Raises error if tasks are inconsistently specified or if
+    one of the tasks raises an error.
+
+    Also raises an error if no message passing is observed in any task for
+    at least `inactivity_timeout` seconds.
+    (useful to kill any stuck jobs in a larger distributed system)
+    """
+    if not tasks:
+        return
+
+    sanity_check_mp_params(tasks)
+    _warn_parameter_overrides(tasks)
+
+    if len(tasks) == 1:
+        (task,) = tasks
+        task.generator(**task.constants_dict)
+        return
+
+    source_task = tasks[0]
+    sink_task = tasks[-1]
+    worker_tasks = tasks[1:-1]
+    clean_completed: Set[int] = set()
+
+    ctx = typing.cast(Union[ForkContext, SpawnContext], mp.get_context(spawn_method))
+
+    n_total_tasks = sum(task.num_workers for task in tasks)
+    # use a BufferedQueue because it synchronizes instantly, unlike PipedQueue or mp.queue
+    err_queue = BufferedQueue(ERR_BUF_SIZE, n_total_tasks + 2, False, ctx)
+
+    # number of processes are of the producing task
+    data_streams = [TaskOutput(t.num_workers, t.packets_in_flight, err_queue) for t in tasks[:-1]]
+    # only one source thread per program
+    threads: List[tuple[str, tr.Thread]] = [
+        (
+            source_task.name,
+            tr.Thread(
+                target=_start_source,
+                args=(source_task, data_streams[0], clean_completed),
+            ),
+        )
+    ]
+    for i, worker_task in enumerate(worker_tasks):
+        for _ in range(worker_task.num_workers):
+            threads.append(
+                (
+                    worker_task.name,
+                    tr.Thread(
+                        target=_start_worker,
+                        args=(
+                            worker_task,
+                            data_streams[i],
+                            data_streams[i + 1],
+                            clean_completed,
+                        ),
+                    ),
+                )
+            )
+
+    for _ in range(sink_task.num_workers):
+        threads.append(
+            (
+                sink_task.name,
+                tr.Thread(
+                    target=_start_sink,
+                    args=(sink_task, data_streams[-1], clean_completed),
+                ),
+            )
+        )
+
+    for name, thread in threads:
+        thread.start()
+
+    thread_id_to_name = {thread.native_id: name for name, thread in threads}
+
+    sentinel_set = {proc.native_id for _name, proc in threads}
+    try:
+        while sentinel_set:
+            for stream in data_streams:
+                # no locking needed to read this value
+                # because the other threads are only writing
+                last_updated_time = max(
+                    float(stream.last_updated_time) for stream in data_streams
+                )
+                if (
+                    inactivity_timeout is not None
+                    and time.monotonic() - last_updated_time > inactivity_timeout
+                ):
+                    raise InactivityError(
+                        f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                    )
+
+            done_sentinels = set()
+            is_first_thread = True
+            for name, thread in threads:
+                if thread.native_id not in sentinel_set:
+                    continue
+                if is_first_thread:
+                    timeout = (
+                        None if inactivity_timeout is None else inactivity_timeout / 10
+                    )
+                    is_first_thread = False
+                else:
+                    timeout = 0
+                thread.join(timeout=timeout)
+                if not thread.is_alive():
+                    done_sentinels.add(thread.native_id)
+                    sentinel_set.remove(thread.native_id)
+
+            # check for handled errors
+            task_name, err = ("", "")
+            for stream in data_streams:
+                with stream.lock:
+                    if stream.error_info is not None and not isinstance(
+                        stream.error_info[1], PropogateErr
+                    ):
+                        # should only be at most one unique error, just raise it
+                        task_name, err = stream.error_info
+                        # somehow this error retains the full trackback, no reason to include the thread-specific traceback here
+                        raise err
+
+            # check for weird unhandled errors (defensive coding, don't know of real world situations which would cause this)
+            for done_id in done_sentinels:
+                if done_id not in clean_completed:
+                    # attempts to catch various errors that aren't caught by python (i.g. sigkill)
+                    proc_err_msg = f"Thead: {done_id} exited improperly"
+                    task_name = thread_id_to_name[done_id]
+                    for stream in data_streams:
+                        stream.set_error(
+                            thread_id_to_name[done_id], TaskError(proc_err_msg)
+                        )
+                    raise TaskError(f"Improper thread exit; {task_name}")
+
+    except BaseException as err:
+        # sets errors in streams in case they aren't already set
+        for stream in data_streams:
+            with stream.lock:
+                if stream.error_info is None:
+                    stream.set_error("main_task", err)
+        # clean up remaining threads so that main process terminates properly
+        for _name, thread in threads:
+            thread.join(15)
+        raise err

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -1,12 +1,6 @@
 import contextlib
 import logging
-from multiprocessing.context import (
-    BaseContext,
-    ForkContext,
-    ForkProcess,
-    SpawnContext,
-    SpawnProcess,
-)
+import multiprocessing as mp
 import multiprocessing.connection as mp_connection
 import os
 import queue
@@ -18,9 +12,14 @@ import traceback
 import typing
 import warnings
 from collections import deque
-from threading import RLock, Semaphore, get_native_id
+from multiprocessing.context import (
+    ForkContext,
+    ForkProcess,
+    SpawnContext,
+    SpawnProcess,
+)
+from threading import RLock, Semaphore
 from typing import Any, Iterable, List, Optional, Set, Union
-import multiprocessing as mp
 
 from pipeline_lib.mp_execution import (
     ERR_BUF_SIZE,
@@ -41,6 +40,7 @@ class PropogateErr(RuntimeError):
 
 
 class TaskOutput:
+    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         num_upstream_tasks: int,
@@ -226,7 +226,6 @@ def execute_thread_queue_errors(
     source_task = tasks[0]
     sink_task = tasks[-1]
     worker_tasks = tasks[1:-1]
-    clean_completed: Set[int] = set()
 
     # number of processes are of the producing task
     data_streams = [
@@ -276,10 +275,11 @@ def execute_thread_queue_errors(
             )
         )
 
-    for name, thread in threads:
+    for _name, thread in threads:
         thread.start()
 
-    for name, thread in threads:
+    for _name, thread in threads:
+        # its OK if these thread joins hang, the main thread can force-kill these untimed joins
         thread.join()
 
 

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -74,7 +74,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # store the updated time to register that progress was made in the pipeline
-            self.last_updated_time.value = time.time()
+            self.last_updated_time.value = time.monotonic()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -315,7 +315,7 @@ def execute_trp(
     err_queue = BufferedQueue(ERR_BUF_SIZE, n_total_tasks + 2, False, ctx)
 
     last_updated_times = [
-        ctx.Value("d", time.time(), lock=False) for _ in range(len(tasks) - 1)
+        ctx.Value("d", time.monotonic(), lock=False) for _ in range(len(tasks) - 1)
     ]
     subprocess = ctx.Process(
         target=execute_thread_queue_errors, args=[tasks, err_queue, last_updated_times]
@@ -341,9 +341,9 @@ def execute_trp(
                         float(last_updated_time.value)
                         for last_updated_time in last_updated_times
                     )
-                    if time.time() - last_updated_time > inactivity_timeout:
+                    if time.monotonic() - last_updated_time > inactivity_timeout:
                         raise InactivityError(
-                            f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                            f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                         )
 
                 task_name, task_err, traceback_str = (None, None, None)

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -1,16 +1,34 @@
-from ctypes import Union
+import contextlib
 import logging
-from multiprocessing.context import BaseContext, ForkContext, SpawnContext
+from multiprocessing.context import (
+    BaseContext,
+    ForkContext,
+    ForkProcess,
+    SpawnContext,
+    SpawnProcess,
+)
+import multiprocessing.connection as mp_connection
+import os
+import queue
+import signal
+import sys
 import threading as tr
 import time
+import traceback
 import typing
 import warnings
 from collections import deque
 from threading import RLock, Semaphore, get_native_id
-from typing import Any, Iterable, List, Optional, Set
+from typing import Any, Iterable, List, Optional, Set, Union
 import multiprocessing as mp
 
-from pipeline_lib.mp_execution import ERR_BUF_SIZE, BufferedQueue, SpawnContextName
+from pipeline_lib.mp_execution import (
+    ERR_BUF_SIZE,
+    PYTHON_ERR_EXIT_CODE,
+    BufferedQueue,
+    SignalReceived,
+    SpawnContextName,
+)
 
 from .pipeline_task import DEFAULT_BUF_SIZE, InactivityError, PipelineTask, TaskError
 from .type_checking import MAX_NUM_WORKERS, sanity_check_mp_params
@@ -23,15 +41,21 @@ class PropogateErr(RuntimeError):
 
 
 class TaskOutput:
-    def __init__(self, num_upstream_tasks: int, packets_in_flight: int, err_queue: BufferedQueue, ctx: BaseContext,) -> None:
+    def __init__(
+        self,
+        num_upstream_tasks: int,
+        packets_in_flight: int,
+        error_queue: BufferedQueue,
+        last_updated_time: Any,
+    ) -> None:
         self.num_tasks_remaining = num_upstream_tasks
-        self.err_queue = err_queue
         self.queue_len = Semaphore(value=0)
         self.packets_space = Semaphore(value=packets_in_flight)
         self.queue: deque = deque(maxlen=packets_in_flight)
-        self.last_updated_time = time.monotonic()
+        self.last_updated_time = last_updated_time
         self.lock = RLock()
-        self.has_error = ctx.Event()
+        self.error_info = None
+        self.error_queue = error_queue
 
     def iter_results(self) -> Iterable[Any]:
         while True:
@@ -50,7 +74,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # store the updated time to register that progress was made in the pipeline
-            self.last_updated_time = time.monotonic()
+            self.last_updated_time = time.time()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -76,64 +100,105 @@ class TaskOutput:
                         self.queue_len.release()
 
     def is_errored(self):
-        return self.has_error.is_set()
+        with self.lock:
+            return self.error_info is not None
 
     def set_error(self, task_name, err, traceback_str):
-        if not self.has_error.is_set():
-            self.err_queue.put((task_name, err, traceback_str))
-            self.has_error.set()
-
+        with self.lock:
+            if self.error_info is None:
+                self.error_info = (task_name, err, traceback_str)
+                self.error_queue.put((task_name, err, traceback_str))
         # release all consumers and producers semaphores so that they exit quickly
         for _i in range(MAX_NUM_WORKERS):
             self.queue_len.release()
             self.packets_space.release()
 
 
-def _start_worker(
-    task: PipelineTask,
-    upstream: TaskOutput,
-    downstream: TaskOutput,
-    clean_completed: Set[int],
-):
-    try:
-        constants = {} if task.constants is None else task.constants
-        generator_input = upstream.iter_results()
-        out_iter = task.generator(generator_input, **constants)
-        downstream.put_results(out_iter)
-    except BaseException as err:  # pylint: disable=broad-except
-        # sets upstream and downstream so that error propagates throughout the system
-        downstream.set_error(task.name, err)
-        upstream.set_error(task.name, err)
-    finally:
-        clean_completed.add(get_native_id())
-
-
 def _start_source(
     task: PipelineTask,
     downstream: TaskOutput,
-    clean_completed: Set[int],
 ):
     try:
         out_iter = task.generator(**task.constants_dict)
         downstream.put_results(out_iter)
-    except BaseException as err:  # pylint: disable=broad-except
-        downstream.set_error(task.name, err)
-    finally:
-        clean_completed.add(get_native_id())
+    except Exception as err:  # pylint: disable=broad-except
+        tb_str = traceback.format_exc()
+        downstream.set_error(task.name, err, tb_str)
+        # exiting directly instead of re-raising error, as that would clutter stderr
+        # with duplicate tracebacks
+        sys.exit(PYTHON_ERR_EXIT_CODE)
+
+
+def _start_worker(
+    task: PipelineTask,
+    upstream: TaskOutput,
+    downstream: TaskOutput,
+):
+    try:
+        generator_input = upstream.iter_results()
+        out_iter = task.generator(generator_input, **task.constants_dict)
+        downstream.put_results(out_iter)
+    except Exception as err:  # pylint: disable=broad-except
+        tb_str = traceback.format_exc()
+        # sets upstream and downstream so that error propagates throughout the system
+        downstream.set_error(task.name, err, tb_str)
+        upstream.set_error(task.name, err, tb_str)
+        # exiting directly instead of re-raising error, as that would clutter stderr
+        # with duplicate tracebacks
+        sys.exit(PYTHON_ERR_EXIT_CODE)
 
 
 def _start_sink(
     task: PipelineTask,
     upstream: TaskOutput,
-    clean_completed: Set[int],
 ):
     try:
         generator_input = upstream.iter_results()
         task.generator(generator_input, **task.constants_dict)
-    except BaseException as err:  # pylint: disable=broad-except
-        upstream.set_error(task.name, err)
+    except Exception as err:  # pylint: disable=broad-except
+        tb_str = traceback.format_exc()
+        upstream.set_error(task.name, err, tb_str)
+        # exiting directly instead of re-raising error, as that would clutter stderr
+        # with duplicate tracebacks
+        sys.exit(PYTHON_ERR_EXIT_CODE)
+
+
+@contextlib.contextmanager
+def sighandler(signums: Set[int], processes: List[Union[ForkProcess, SpawnProcess]]):
+    def sigterm_handler(signum, _frame):
+        # propogate the signal to children processes
+        for proc in processes:
+            # os.kill just sends a signal like the command line tool
+            try:
+                os.kill(proc.ident, signum)
+            except ProcessLookupError:
+                logger.warning(f"Failed to find process {proc.ident}")
+        # throw an exception to trigger the exceptional cleanup policy
+        raise SignalReceived(signum)
+
+    old_handlings = {}
+    for signum in signums:
+        old_handlings[signum] = signal.getsignal(signum)
+        signal.signal(signum, sigterm_handler)
+    did_reset_handling = False
+    try:
+        yield
+    except SignalReceived as sigerr:
+        if sigerr.signum in signums:
+            # if the signal was raised by our signal handler, then retry the old signal handling method
+            # so the end user of the library can handle signals in the way they wish to
+            for signum, old_handling in old_handlings.items():
+                signal.signal(signum, old_handling)
+            did_reset_handling = True
+            signal.raise_signal(sigerr.signum)
+            # else re-raise error
+        else:
+            raise sigerr
     finally:
-        clean_completed.add(get_native_id())
+        # only reset handling here if not done in except statement
+        if not did_reset_handling:
+            for signum, old_handling in old_handlings.items():
+                signal.signal(signum, old_handling)
 
 
 def _warn_parameter_overrides(tasks: List[PipelineTask]):
@@ -147,10 +212,81 @@ def _warn_parameter_overrides(tasks: List[PipelineTask]):
             )
 
 
+def execute_thread_queue_errors(
+    tasks: List[PipelineTask], err_queue: BufferedQueue, last_updated_times: List[Any]
+):
+    if not tasks:
+        return
+
+    if len(tasks) == 1:
+        (task,) = tasks
+        task.generator(**task.constants_dict)
+        return
+
+    source_task = tasks[0]
+    sink_task = tasks[-1]
+    worker_tasks = tasks[1:-1]
+    clean_completed: Set[int] = set()
+
+    # number of processes are of the producing task
+    data_streams = [
+        TaskOutput(t.num_workers, t.packets_in_flight, err_queue, last_update_time)
+        for t, last_update_time in zip(tasks[:-1], last_updated_times)
+    ]
+    # only one source thread per program
+    threads: List[tuple[str, tr.Thread]] = [
+        (
+            source_task.name,
+            tr.Thread(
+                target=_start_source,
+                args=(
+                    source_task,
+                    data_streams[0],
+                ),
+            ),
+        )
+    ]
+    for i, worker_task in enumerate(worker_tasks):
+        for _ in range(worker_task.num_workers):
+            threads.append(
+                (
+                    worker_task.name,
+                    tr.Thread(
+                        target=_start_worker,
+                        args=(
+                            worker_task,
+                            data_streams[i],
+                            data_streams[i + 1],
+                        ),
+                    ),
+                )
+            )
+
+    for _ in range(sink_task.num_workers):
+        threads.append(
+            (
+                sink_task.name,
+                tr.Thread(
+                    target=_start_sink,
+                    args=(
+                        sink_task,
+                        data_streams[-1],
+                    ),
+                ),
+            )
+        )
+
+    for name, thread in threads:
+        thread.start()
+
+    for name, thread in threads:
+        thread.join()
+
+
 def execute_trp(
     tasks: List[PipelineTask],
     spawn_method: SpawnContextName,
-    inactivity_timeout: Optional[float]
+    inactivity_timeout: Optional[float],
 ):
     # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     """
@@ -173,127 +309,86 @@ def execute_trp(
         task.generator(**task.constants_dict)
         return
 
-    source_task = tasks[0]
-    sink_task = tasks[-1]
-    worker_tasks = tasks[1:-1]
-    clean_completed: Set[int] = set()
-
     ctx = typing.cast(Union[ForkContext, SpawnContext], mp.get_context(spawn_method))
-
     n_total_tasks = sum(task.num_workers for task in tasks)
     # use a BufferedQueue because it synchronizes instantly, unlike PipedQueue or mp.queue
     err_queue = BufferedQueue(ERR_BUF_SIZE, n_total_tasks + 2, False, ctx)
 
-    # number of processes are of the producing task
-    data_streams = [TaskOutput(t.num_workers, t.packets_in_flight, err_queue) for t in tasks[:-1]]
-    # only one source thread per program
-    threads: List[tuple[str, tr.Thread]] = [
-        (
-            source_task.name,
-            tr.Thread(
-                target=_start_source,
-                args=(source_task, data_streams[0], clean_completed),
-            ),
-        )
+    last_updated_times = [
+        ctx.Value("d", time.time(), lock=False) for _ in range(len(tasks) - 1)
     ]
-    for i, worker_task in enumerate(worker_tasks):
-        for _ in range(worker_task.num_workers):
-            threads.append(
-                (
-                    worker_task.name,
-                    tr.Thread(
-                        target=_start_worker,
-                        args=(
-                            worker_task,
-                            data_streams[i],
-                            data_streams[i + 1],
-                            clean_completed,
-                        ),
-                    ),
-                )
-            )
+    subprocess = ctx.Process(
+        target=execute_thread_queue_errors, args=[tasks, err_queue, last_updated_times]
+    )
+    subprocess.start()
 
-    for _ in range(sink_task.num_workers):
-        threads.append(
-            (
-                sink_task.name,
-                tr.Thread(
-                    target=_start_sink,
-                    args=(sink_task, data_streams[-1], clean_completed),
+    # signal setup must be *after* all new processes are started, so that main processes
+    # signal handling won't be copied over to children
+    with sighandler({signal.SIGINT, signal.SIGTERM}, [subprocess]):
+        done_sentinels = None
+        try:
+            done_sentinels = mp_connection.wait(
+                [subprocess.sentinel],
+                timeout=(
+                    None if inactivity_timeout is None else inactivity_timeout / 10
                 ),
             )
-        )
-
-    for name, thread in threads:
-        thread.start()
-
-    thread_id_to_name = {thread.native_id: name for name, thread in threads}
-
-    sentinel_set = {proc.native_id for _name, proc in threads}
-    try:
-        while sentinel_set:
-            for stream in data_streams:
-                # no locking needed to read this value
-                # because the other threads are only writing
+            last_updated_time = max(
+                float(last_updated_time.value)
+                for last_updated_time in last_updated_times
+            )
+            if inactivity_timeout is not None and not done_sentinels:
+                # this means the timeout ended,
+                # time to check all of the task outputs timers
                 last_updated_time = max(
-                    float(stream.last_updated_time) for stream in data_streams
+                    float(last_updated_time.value)
+                    for last_updated_time in last_updated_times
                 )
-                if (
-                    inactivity_timeout is not None
-                    and time.monotonic() - last_updated_time > inactivity_timeout
-                ):
+                if time.time() - last_updated_time > inactivity_timeout:
                     raise InactivityError(
-                        f"Last updated time was {time.monotonic() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                        f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
                     )
 
-            done_sentinels = set()
-            is_first_thread = True
-            for name, thread in threads:
-                if thread.native_id not in sentinel_set:
-                    continue
-                if is_first_thread:
-                    timeout = (
-                        None if inactivity_timeout is None else inactivity_timeout / 10
+            if done_sentinels:
+                done_id = done_sentinels[0]
+                assert isinstance(
+                    done_id, int
+                ), f"mp_connection.wait returned unexpected type: {done_id}"
+                # for some reason needs a join, or the exitcode doesn't sync properly
+                # but it has already exited, so this should finish very quickly
+                subprocess.join()
+                if subprocess.exitcode is None:
+                    # unsure what could cause this, but we see it in production sometimes
+                    # when an instance is shutting down
+                    logger.warning("Child process joined with exitcode None.")
+                elif subprocess.exitcode != 0:
+                    # attempts to catch segfaults and other errors that cannot be caught by python (i.g. sigkill)
+                    raise TaskError(
+                        f"Process: {subprocess.name} exited with non-zero code {subprocess.exitcode}"
                     )
-                    is_first_thread = False
-                else:
-                    timeout = 0
-                thread.join(timeout=timeout)
-                if not thread.is_alive():
-                    done_sentinels.add(thread.native_id)
-                    sentinel_set.remove(thread.native_id)
 
-            # check for handled errors
-            task_name, err = ("", "")
-            for stream in data_streams:
-                with stream.lock:
-                    if stream.error_info is not None and not isinstance(
-                        stream.error_info[1], PropogateErr
-                    ):
-                        # should only be at most one unique error, just raise it
-                        task_name, err = stream.error_info
-                        # somehow this error retains the full trackback, no reason to include the thread-specific traceback here
-                        raise err
+            try:
+                # first entry on the error queue should hopefully be the original error, just raise that one single error
+                (task_name, task_err, traceback_str), _ = err_queue.get()
+                # should only be at most one unique error, just raise it
+                # the main error needs to be the main raise for type-based exception catching to work
+                raise task_err from TaskError(
+                    f"Task; {task_name} errored\n{traceback_str}\n{task_err}"
+                )
+            except queue.Empty:
+                # if the error queue is empty, then there is no error
+                pass
 
-            # check for weird unhandled errors (defensive coding, don't know of real world situations which would cause this)
-            for done_id in done_sentinels:
-                if done_id not in clean_completed:
-                    # attempts to catch various errors that aren't caught by python (i.g. sigkill)
-                    proc_err_msg = f"Thead: {done_id} exited improperly"
-                    task_name = thread_id_to_name[done_id]
-                    for stream in data_streams:
-                        stream.set_error(
-                            thread_id_to_name[done_id], TaskError(proc_err_msg)
-                        )
-                    raise TaskError(f"Improper thread exit; {task_name}")
+        except BaseException as err:  # pylint: disable=broad-except
+            # joins process as cleanup if they successfully exited
+            # give them a decent amount of time to process their current task and exit cleanly
+            subprocess.join(timeout=15.0)
+            # escalate, send sigterm to process
+            subprocess.terminate()
+            # wait for terminate signal to propagate through the process
+            subprocess.join(timeout=5.0)
+            # force kill the process (only if they are refusing to terminate cleanly)
+            subprocess.kill()
+            subprocess.join()
 
-    except BaseException as err:
-        # sets errors in streams in case they aren't already set
-        for stream in data_streams:
-            with stream.lock:
-                if stream.error_info is None:
-                    stream.set_error("main_task", err)
-        # clean up remaining threads so that main process terminates properly
-        for _name, thread in threads:
-            thread.join(15)
-        raise err
+            raise err

--- a/pipeline_lib/trp_execution.py
+++ b/pipeline_lib/trp_execution.py
@@ -74,7 +74,7 @@ class TaskOutput:
             self.packets_space.release()
 
             # store the updated time to register that progress was made in the pipeline
-            self.last_updated_time = time.time()
+            self.last_updated_time.value = time.time()
 
     def put_results(self, iterable: Iterable[Any]):
         iterator = iter(iterable)
@@ -327,68 +327,69 @@ def execute_trp(
     with sighandler({signal.SIGINT, signal.SIGTERM}, [subprocess]):
         done_sentinels = None
         try:
-            done_sentinels = mp_connection.wait(
-                [subprocess.sentinel],
-                timeout=(
-                    None if inactivity_timeout is None else inactivity_timeout / 10
-                ),
-            )
-            last_updated_time = max(
-                float(last_updated_time.value)
-                for last_updated_time in last_updated_times
-            )
-            if inactivity_timeout is not None and not done_sentinels:
-                # this means the timeout ended,
-                # time to check all of the task outputs timers
-                last_updated_time = max(
-                    float(last_updated_time.value)
-                    for last_updated_time in last_updated_times
+            while not done_sentinels:
+                done_sentinels = mp_connection.wait(
+                    [subprocess.sentinel],
+                    timeout=(
+                        None if inactivity_timeout is None else inactivity_timeout / 10
+                    ),
                 )
-                if time.time() - last_updated_time > inactivity_timeout:
-                    raise InactivityError(
-                        f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                if inactivity_timeout is not None and not done_sentinels:
+                    # this means the timeout ended,
+                    # time to check all of the task outputs timers
+                    last_updated_time = max(
+                        float(last_updated_time.value)
+                        for last_updated_time in last_updated_times
+                    )
+                    if time.time() - last_updated_time > inactivity_timeout:
+                        raise InactivityError(
+                            f"Last updated time was {time.time() - last_updated_time}s ago, pipeline inactivity timeout is {inactivity_timeout}s."
+                        )
+
+                task_name, task_err, traceback_str = (None, None, None)
+                try:
+                    # first entry on the error queue should hopefully be the original error, just raise that one single error
+                    (task_name, task_err, traceback_str), _ = err_queue.get()
+                except queue.Empty:
+                    # if the error queue is empty, then there is no error
+                    pass
+                if task_err is not None:
+                    # should only be at most one unique error, just raise it
+                    # the main error needs to be the main raise for type-based exception catching to work
+                    raise task_err from TaskError(
+                        f"Task; {task_name} errored\n{traceback_str}\n{task_err}"
                     )
 
-            if done_sentinels:
-                done_id = done_sentinels[0]
-                assert isinstance(
-                    done_id, int
-                ), f"mp_connection.wait returned unexpected type: {done_id}"
-                # for some reason needs a join, or the exitcode doesn't sync properly
-                # but it has already exited, so this should finish very quickly
-                subprocess.join()
-                if subprocess.exitcode is None:
-                    # unsure what could cause this, but we see it in production sometimes
-                    # when an instance is shutting down
-                    logger.warning("Child process joined with exitcode None.")
-                elif subprocess.exitcode != 0:
-                    # attempts to catch segfaults and other errors that cannot be caught by python (i.g. sigkill)
-                    raise TaskError(
-                        f"Process: {subprocess.name} exited with non-zero code {subprocess.exitcode}"
-                    )
-
-            try:
-                # first entry on the error queue should hopefully be the original error, just raise that one single error
-                (task_name, task_err, traceback_str), _ = err_queue.get()
-                # should only be at most one unique error, just raise it
-                # the main error needs to be the main raise for type-based exception catching to work
-                raise task_err from TaskError(
-                    f"Task; {task_name} errored\n{traceback_str}\n{task_err}"
-                )
-            except queue.Empty:
-                # if the error queue is empty, then there is no error
-                pass
+                if done_sentinels:
+                    done_id = done_sentinels[0]
+                    assert isinstance(
+                        done_id, int
+                    ), f"mp_connection.wait returned unexpected type: {done_id}"
+                    # for some reason needs a join, or the exitcode doesn't sync properly
+                    # but it has already exited, so this should finish very quickly
+                    subprocess.join()
+                    if subprocess.exitcode is None:
+                        # unsure what could cause this, but we see it in production sometimes
+                        # when an instance is shutting down
+                        logger.warning("Child process joined with exitcode None.")
+                    elif subprocess.exitcode != 0:
+                        # attempts to catch segfaults and other errors that cannot be caught by python (i.g. sigkill)
+                        raise TaskError(
+                            f"Process: {subprocess.name} exited with non-zero code {subprocess.exitcode}"
+                        )
 
         except BaseException as err:  # pylint: disable=broad-except
+
             # joins process as cleanup if they successfully exited
             # give them a decent amount of time to process their current task and exit cleanly
-            subprocess.join(timeout=15.0)
-            # escalate, send sigterm to process
-            subprocess.terminate()
-            # wait for terminate signal to propagate through the process
-            subprocess.join(timeout=5.0)
-            # force kill the process (only if they are refusing to terminate cleanly)
-            subprocess.kill()
-            subprocess.join()
+            if not subprocess.exitcode:
+                # escalate, send sigterm to process
+                subprocess.terminate()
+                # wait for terminate signal to propagate through the process
+                subprocess.join(timeout=5.0)
+            if not subprocess.exitcode:
+                # force kill the process (only if they are refusing to terminate cleanly)
+                subprocess.kill()
+                subprocess.join()
 
             raise err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,5 @@ disable = [
     "missing-function-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
     "missing-module-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
     "missing-class-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
-    "duplicate-code", # copypasta is an intentional design choice meant to improve readbility over editability
+    "duplicate-code", # copypasta is an intentional design choice meant to improve readbility and fine-grained control over each and every execution method to maximize efficiency and reliability over broad edits and refactors
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ disable = [
     "missing-function-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
     "missing-module-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
     "missing-class-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
+    "duplicate-code", # copypasta is an intentional design choice meant to improve readbility over editability
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ profile = "black"
 disable = [
     "line-too-long", # We use black to control this.
     "logging-fstring-interpolation", # Logging in this repo is always fairly high severity, not an important rule
-    "missing-function-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
-    "missing-module-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
-    "missing-class-docstring", # TODO : REMOVE - TEMPORARY DURING INITIAL DEVELOPMENT
     "duplicate-code", # copypasta is an intentional design choice meant to improve readbility and fine-grained control over each and every execution method to maximize efficiency and reliability over broad edits and refactors
+    "missing-function-docstring",
+    "missing-module-docstring",
+    "missing-class-docstring",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "0.5.0"
+version = "0.6.0"
 name = "pipeline_lib"
 description = "A streaming pipeline accelerator for Python"
 readme = "README.md"

--- a/test/test_execution_correctness.py
+++ b/test/test_execution_correctness.py
@@ -288,4 +288,4 @@ def test_many_large_packets_correctness(
 
 
 if __name__ == "__main__":
-    test_full_synchronization("/tmp", "thread")
+    test_execute_basic("process-spawn-threading")

--- a/test/test_execution_correctness.py
+++ b/test/test_execution_correctness.py
@@ -288,4 +288,4 @@ def test_many_large_packets_correctness(
 
 
 if __name__ == "__main__":
-    test_execute_basic("process-spawn-threading")
+    test_execute_basic("thread-in-process-spawn")

--- a/test/test_execution_error.py
+++ b/test/test_execution_error.py
@@ -258,7 +258,7 @@ def test_single_worker_error(parallelism: ParallelismStrategy):
     """
     mp_context = (
         mp.get_context("spawn")
-        if parallelism == "process-spawn" or parallelism == "process-spawn-threading"
+        if parallelism == "process-spawn" or parallelism == "thread-in-process-spawn"
         else mp
     )
     started_event = mp_context.Event()
@@ -306,8 +306,8 @@ def test_single_worker_unexpected_exit(parallelism: ParallelismStrategy):
     process_context_map: Dict[ParallelismStrategy, str] = {
         "process-fork": "fork",
         "process-spawn": "spawn",
-        "process-fork-threading": "fork",
-        "process-spawn-threading": "spawn",
+        "thread-in-process-fork": "fork",
+        "thread-in-process-spawn": "spawn",
     }
     ctx = mp.get_context(process_context_map[parallelism])
     started_event = ctx.Event()

--- a/test/test_execution_error.py
+++ b/test/test_execution_error.py
@@ -21,6 +21,7 @@ from .test_utils import (
     process_parallelism_options,
     sleeper,
     thread_parallelism_options,
+    thread_in_process_parallelism_options,
 )
 
 
@@ -200,7 +201,11 @@ def test_main_process_signal(
     child_procs = psutil.Process(proc.pid).children()
 
     process_parallelism = set(process_parallelism_options)
-    if parallelism in process_parallelism:
+    if parallelism in thread_in_process_parallelism_options:
+        # there are 1 child processes we expect
+        # the container process that hosts all the worker threads
+        assert len(child_procs) == 1
+    elif parallelism in process_parallelism:
         # there are 3 child processes we expect
         # 1 generate_infinite process, 2 consume_infinite_ints processes
         assert len(child_procs) == 3
@@ -251,7 +256,11 @@ def test_single_worker_error(parallelism: ParallelismStrategy):
     if one process dies and the others do not, then it should still raise an exception,
     as the dead process might have consumed an important message
     """
-    mp_context = mp.get_context("spawn") if parallelism == "process-spawn" else mp
+    mp_context = (
+        mp.get_context("spawn")
+        if parallelism == "process-spawn" or parallelism == "process-spawn-threading"
+        else mp
+    )
     started_event = mp_context.Event()
     tasks = [
         PipelineTask(
@@ -297,6 +306,8 @@ def test_single_worker_unexpected_exit(parallelism: ParallelismStrategy):
     process_context_map: Dict[ParallelismStrategy, str] = {
         "process-fork": "fork",
         "process-spawn": "spawn",
+        "process-fork-threading": "fork",
+        "process-spawn-threading": "spawn",
     }
     ctx = mp.get_context(process_context_map[parallelism])
     started_event = ctx.Event()
@@ -360,4 +371,4 @@ def test_hang_message_passing_timeout(
 
 
 if __name__ == "__main__":
-    test_hang_message_passing_timeout(1000, "process-fork")
+    test_single_worker_error("process-fork")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,10 +14,14 @@ thread_parallelism_options: List[ParallelismStrategy] = [
     "thread",
     "process-fork",
     "process-spawn",
+    "process-spawn-threading",
+    "process-fork-threading",
 ]
 process_parallelism_options: List[ParallelismStrategy] = [
     "process-fork",
     "process-spawn",
+    "process-spawn-threading",
+    "process-fork-threading",
 ]
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,18 +14,18 @@ thread_parallelism_options: List[ParallelismStrategy] = [
     "thread",
     "process-fork",
     "process-spawn",
-    "process-spawn-threading",
-    "process-fork-threading",
+    "thread-in-process-spawn",
+    "thread-in-process-fork",
 ]
 process_parallelism_options: List[ParallelismStrategy] = [
     "process-fork",
     "process-spawn",
-    "process-spawn-threading",
-    "process-fork-threading",
+    "thread-in-process-spawn",
+    "thread-in-process-fork",
 ]
 thread_in_process_parallelism_options: List[ParallelismStrategy] = [
-    "process-spawn-threading",
-    "process-fork-threading",
+    "thread-in-process-spawn",
+    "thread-in-process-fork",
 ]
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -23,6 +23,10 @@ process_parallelism_options: List[ParallelismStrategy] = [
     "process-spawn-threading",
     "process-fork-threading",
 ]
+thread_in_process_parallelism_options: List[ParallelismStrategy] = [
+    "process-spawn-threading",
+    "process-fork-threading",
+]
 
 
 def sleeper(vals: Iterable[int], sleep_time: float) -> Iterable[int]:


### PR DESCRIPTION
Threads can be much more efficient than processes at data communication when it comes to high throughput, inter-pipeline step data.

However, threads have much poorer error handling functionality:

* No way to force kill a hanging thread
* No way to check for a OOM error and recover gracefully
* Python interpreter is shared in case a bug or memory corruption corrupts the interpreter state
* Etc.

The idea is to get the best of both worlds by spawning worker threads inside a subprocess process that contains those threads. Then, the whole pipeline can be force killed, die from OOM while the main thread recovers, etc. However, the high-throughput data transfers can happen between the contained threads.